### PR TITLE
[fix] Chromium net::ERR_HTTP2_PROTOCOL_ERROR 200

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -13,8 +13,8 @@ location __PATH__/ {
     client_max_body_size __MAX_FILE_SIZE__M;
 
     if ($request_uri ~* ^/(img|css|font|js)/) {
-         more_set_headers Expires "Thu, 31 Dec 2037 23:55:55 GMT";
-         more_set_headers Cache-Control "public, max-age=315360000";
+         #more_set_headers Expires "Thu, 31 Dec 2037 23:55:55 GMT";
+         #more_set_headers Cache-Control "public, max-age=315360000";
     }
 
     proxy_pass http://127.0.0.1:__PORT____PATH__;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -13,6 +13,8 @@ location __PATH__/ {
     client_max_body_size __MAX_FILE_SIZE__M;
 
     if ($request_uri ~* ^/(img|css|font|js)/) {
+         # If uncommented, it triggers some net::ERR_HTTP2_PROTOCOL_ERROR
+         # with chromium
          #more_set_headers Expires "Thu, 31 Dec 2037 23:55:55 GMT";
          #more_set_headers Cache-Control "public, max-age=315360000";
     }


### PR DESCRIPTION
## Problem
https://forum.yunohost.org/t/lufi-casse-sur-certains-navigateurs/12759/2

## Solution
Comment some cache line in nginx conf

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/lufi_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/lufi_ynh%20PR-NUM-%20(USERNAME)/)  
