### PR TITLE
Allow LDAP on public and remove legacy permission and various fixes

### DIFF
--- a/check_process
+++ b/check_process
@@ -3,9 +3,9 @@
 	; Manifest
 		domain="domain.tld"
 		path="/path"
+		is_public=1
 		max_file_size=100
 		use_ldap=0
-		is_public=1
 	; Checks
 		pkg_linter=1
 		setup_sub_dir=1

--- a/check_process
+++ b/check_process
@@ -5,6 +5,7 @@
 		path="/path"
 		max_file_size=100
 		is_public=1
+		use_ldap=0
 		admin="john"
 	; Checks
 		pkg_linter=1

--- a/conf/lufi.conf.template
+++ b/conf/lufi.conf.template
@@ -59,7 +59,7 @@
     # max file size, in octets
     # you can write it 100*1024*1024
     # optional, no default
-    max_file_size     => __MAX_FILE_SIZE__*1024*1024,
+    __MAX_SIZE_SET__max_file_size     => __MAX_FILE_SIZE__*1024*1024,
 
     # if you want to have piwik statistics, provide a piwik image tracker
     # only the image tracker is allowed, no javascript
@@ -199,20 +199,20 @@
     # set `ldap` if you want that only authenticated users can upload files
     # please note that everybody can still download files
     # optional, no default
-    __USE_LDAP__ldap => {
-    __USE_LDAP__    uri         => 'ldap://localhost:389',                      # server URI
-    __USE_LDAP__    user_tree   => 'dc=yunohost,dc=org',                        # search base DN
-    __USE_LDAP__    bind_dn     => 'ou=users,dc=yunohost,dc=org',               # search bind DN
-    __USE_LDAP__    #bind_pwd    => 'secr3t',                                   # search bind password
-    __USE_LDAP__    user_attr   => 'uid',                                       # user attribute (uid, mail, sAMAccountName, etc.)
-    __USE_LDAP__    user_filter => '(&(objectClass=posixAccount)(permission=cn=__APP__.main,ou=permission,dc=yunohost,dc=org))', # user filter (to exclude some users, etc.)
-    __USE_LDAP__    # optional start_tls configuration. See https://metacpan.org/pod/distribution/perl-ldap/lib/Net/LDAP.pod#start_tls
-    __USE_LDAP__    # don't set or uncomment if you don't want to configure it
-    __USE_LDAP__    #start_tls => {
-    __USE_LDAP__    #   verify     => 'optional',
-    __USE_LDAP__    #   clientcert => '/etc/ssl/certs/ca-bundle.pem'
-    __USE_LDAP__    #}
-    __USE_LDAP__},
+    __LDAP__ldap => {
+    __LDAP__    uri         => 'ldap://localhost:389',                      # server URI
+    __LDAP__    user_tree   => 'dc=yunohost,dc=org',                        # search base DN
+    __LDAP__    bind_dn     => 'ou=users,dc=yunohost,dc=org',               # search bind DN
+    __LDAP__    #bind_pwd    => 'secr3t',                                   # search bind password
+    __LDAP__    user_attr   => 'uid',                                       # user attribute (uid, mail, sAMAccountName, etc.)
+    __LDAP__    user_filter => '(&(objectClass=posixAccount)(permission=cn=__APP__.main,ou=permission,dc=yunohost,dc=org))', # user filter (to exclude some users, etc.)
+    __LDAP__    # optional start_tls configuration. See https://metacpan.org/pod/distribution/perl-ldap/lib/Net/LDAP.pod#start_tls
+    __LDAP__    # don't set or uncomment if you don't want to configure it
+    __LDAP__    #start_tls => {
+    __LDAP__    #   verify     => 'optional',
+    __LDAP__    #   clientcert => '/etc/ssl/certs/ca-bundle.pem'
+    __LDAP__    #}
+    __LDAP__},
 
     # if you've set ldap above, the session will last `session_duration` seconds before
     # the user needs to reauthenticate

--- a/conf/lufi.conf.template
+++ b/conf/lufi.conf.template
@@ -199,20 +199,20 @@
     # set `ldap` if you want that only authenticated users can upload files
     # please note that everybody can still download files
     # optional, no default
-    __IS_PUBLIC__ldap => {
-    __IS_PUBLIC__    uri         => 'ldap://localhost:389',                      # server URI
-    __IS_PUBLIC__    user_tree   => 'dc=yunohost,dc=org',                        # search base DN
-    __IS_PUBLIC__    bind_dn     => 'ou=users,dc=yunohost,dc=org',               # search bind DN
-    __IS_PUBLIC__    #bind_pwd    => 'secr3t',                                   # search bind password
-    __IS_PUBLIC__    user_attr   => 'uid',                                       # user attribute (uid, mail, sAMAccountName, etc.)
-    __IS_PUBLIC__    #user_filter => '(!(uid=ldap_user))',                       # user filter (to exclude some users, etc.)
-    __IS_PUBLIC__    # optional start_tls configuration. See https://metacpan.org/pod/distribution/perl-ldap/lib/Net/LDAP.pod#start_tls
-    __IS_PUBLIC__    # don't set or uncomment if you don't want to configure it
-    __IS_PUBLIC__    #start_tls => {
-    __IS_PUBLIC__    #   verify     => 'optional',
-    __IS_PUBLIC__    #   clientcert => '/etc/ssl/certs/ca-bundle.pem'
-    __IS_PUBLIC__    #}
-    __IS_PUBLIC__},
+    __USE_LDAP__ldap => {
+    __USE_LDAP__    uri         => 'ldap://localhost:389',                      # server URI
+    __USE_LDAP__    user_tree   => 'dc=yunohost,dc=org',                        # search base DN
+    __USE_LDAP__    bind_dn     => 'ou=users,dc=yunohost,dc=org',               # search bind DN
+    __USE_LDAP__    #bind_pwd    => 'secr3t',                                   # search bind password
+    __USE_LDAP__    user_attr   => 'uid',                                       # user attribute (uid, mail, sAMAccountName, etc.)
+    __USE_LDAP__    user_filter => '(&(objectClass=posixAccount)(permission=cn=__APP__.main,ou=permission,dc=yunohost,dc=org))', # user filter (to exclude some users, etc.)
+    __USE_LDAP__    # optional start_tls configuration. See https://metacpan.org/pod/distribution/perl-ldap/lib/Net/LDAP.pod#start_tls
+    __USE_LDAP__    # don't set or uncomment if you don't want to configure it
+    __USE_LDAP__    #start_tls => {
+    __USE_LDAP__    #   verify     => 'optional',
+    __USE_LDAP__    #   clientcert => '/etc/ssl/certs/ca-bundle.pem'
+    __USE_LDAP__    #}
+    __USE_LDAP__},
 
     # if you've set ldap above, the session will last `session_duration` seconds before
     # the user needs to reauthenticate

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,10 +1,6 @@
 #sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
 location __PATH__/ {
 
-    if ($scheme = http) {
-        rewrite ^ https://$server_name$request_uri? permanent;
-    }
-
     # This is important for user's privacy!
     access_log off;
     error_log /var/log/nginx/lufi.error.log;

--- a/manifest.json
+++ b/manifest.json
@@ -49,8 +49,25 @@
 				"default": "100"
 			},
 			{
+				"name": "use_ldap",
+				"type": "boolean",
+				"ask": {
+					"en": "Install Lufi with LDAP configuration?",
+					"fr": "Installer Lufi avec la configuration LDAP ?"
+				},
+				"help": {
+					"en": "A Lufi with LDAP enabled will allow only YunoHost users to upload.",
+					"fr": "Un Lufi avec LDAP activé autorisera seulement les utilisateurs YunoHost à téléverser."
+				},
+				"default": false
+			},
+			{
 				"name": "is_public",
 				"type": "boolean",
+				"help": {
+					"en": "A public Lufi will be publicly visible for everyone.",
+					"fr": "Un Lufi public sera visible publiquement pour tous."
+				},
 				"default": true
 			}
 		]

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
 		"email": "win10@tutanota.com, cyp@rouquin.me"
 	},
 	"requirements": {
-        "yunohost": ">= 4.2.3"
+        "yunohost": ">= 4.3"
 	},
 	"multi_instance": true,
 	"services": [

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 		"en": "Self hosting files and sharing anonymous application",
 		"fr": "Application d'hébergement et de partage de fichiers anonyme"
 	},
-	"version": "0.05.16~ynh1",
+	"version": "0.05.16~ynh2",
 	"url": "https://git.framasoft.org/luc/lufi",
 	"upstream": {
         "license": "AGPL-3.0-or-later",

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -31,7 +31,7 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 
 # Add settings here as needed by your application
 port=$(ynh_app_setting_get --app=$app --key=port)
-is_public=$(ynh_app_setting_get --app=$app --key=is_public)
+use_ldap=$(ynh_app_setting_get --app=$app --key=use_ldap)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_pwd=$(ynh_app_setting_get --app=$app --key=psqlpwd)
 db_user=$db_name
@@ -133,34 +133,17 @@ if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
 	ynh_replace_string --match_string="max_file_size" --replace_string="#max_file_size" --target_file="$config"
 fi
 ynh_replace_string --match_string="__SECRET__" --replace_string="$secret" --target_file="$config"
-if [ $is_public -eq 0 ];
+if [ $use_ldap -eq 1 ];
 then
-	ynh_replace_string --match_string="__IS_PUBLIC__" --replace_string="" --target_file="$config"
+	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="" --target_file="$config"
+	ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
 else
-	ynh_replace_string --match_string="__IS_PUBLIC__" --replace_string="#" --target_file="$config"
+	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="#" --target_file="$config"
 fi
 ynh_store_file_checksum --file="$config"
 
 chmod 600 $final_path/lufi.conf
 chown $app:$app $final_path/lufi.conf
-
-#=================================================
-# UPDATE SSOWAT
-#=================================================
-ynh_script_progression --message="Reconfiguring permissions..."
-
-ynh_permission_update --permission="main" --add="visitors"
-
-if [ $is_public -eq 0 ]
-then
-	if [ "$path_url" == "/" ]; then
-	    # If the path is /, clear it to prevent any error with the regex.
-	    path_url=""
-	fi
-	# Modify the domain to be used in a regex
-	domain_regex=$(echo "$domain" | sed 's@-@.@g')
-	ynh_app_setting_set --app=$app --key=protected_regex --value="$domain_regex$path_url/stats$","$domain_regex$path_url/manifest.webapp$","$domain_regex$path_url/$","$domain_regex$path_url/d/.*$","$domain_regex$path_url/m/.*$"
-fi
 
 #=================================================
 # GENERIC FINALISATION

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -119,28 +119,18 @@ ynh_script_progression --message="Configuring lufi..."
 domain="$new_domain"
 path_url="$new_path"
 
-config=${final_path}/lufi.conf
-ynh_backup_if_checksum_is_different --file="$config"
-cp ../conf/lufi.conf.template "$config"
-ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --target_file="$config"
-ynh_replace_string --match_string="__PATH__" --replace_string="$path_url" --target_file="$config"
-ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file="$config"
-ynh_replace_string --match_string="__DB_NAME__" --replace_string="$db_name" --target_file="$config"
-ynh_replace_string --match_string="__DB_USER__" --replace_string="$db_user" --target_file="$config"
-ynh_replace_string --match_string="__DB_PWD__" --replace_string="$db_pwd" --target_file="$config"
-ynh_replace_string --match_string="__MAX_FILE_SIZE__" --replace_string="$max_file_size" --target_file="$config"
-if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
-	ynh_replace_string --match_string="max_file_size" --replace_string="#max_file_size" --target_file="$config"
-fi
-ynh_replace_string --match_string="__SECRET__" --replace_string="$secret" --target_file="$config"
+ldap="#"
 if [ $use_ldap -eq 1 ];
 then
-	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="" --target_file="$config"
-	ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
-else
-	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="#" --target_file="$config"
+	ldap=""
 fi
-ynh_store_file_checksum --file="$config"
+
+max_size_set=""
+if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
+	max_size_set="#"
+fi
+
+ynh_add_config --template="../conf/lufi.conf.template" --destination="$final_path/lufi.conf"
 
 chmod 600 $final_path/lufi.conf
 chown $app:$app $final_path/lufi.conf

--- a/scripts/install
+++ b/scripts/install
@@ -126,29 +126,18 @@ ynh_add_nginx_config max_file_size
 #=================================================
 ynh_script_progression --message="Configuring $app..."
 
-config=${final_path}/lufi.conf
-cp ../conf/lufi.conf.template "$config"
-ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --target_file="$config"
-ynh_replace_string --match_string="__PATH__" --replace_string="$path_url" --target_file="$config"
-ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file="$config"
-ynh_replace_string --match_string="__DB_NAME__" --replace_string="$db_name" --target_file="$config"
-ynh_replace_string --match_string="__DB_USER__" --replace_string="$db_user" --target_file="$config"
-ynh_replace_string --match_string="__DB_PWD__" --replace_string="$db_pwd" --target_file="$config"
-ynh_replace_string --match_string="__MAX_FILE_SIZE__" --replace_string="$max_file_size" --target_file="$config"
-if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
-	ynh_replace_string --match_string="max_file_size" --replace_string="#max_file_size" --target_file="$config"
-fi
-ynh_replace_string --match_string="__SECRET__" --replace_string="$secret" --target_file="$config"
-
+ldap="#"
 if [ $use_ldap -eq 1 ];
 then
-	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="" --target_file="$config"
-	ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
-else
-	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="#" --target_file="$config"
+	ldap=""
 fi
 
-ynh_store_file_checksum --file="$config"
+max_size_set=""
+if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
+	max_size_set="#"
+fi
+
+ynh_add_config --template="../conf/lufi.conf.template" --destination="$final_path/lufi.conf"
 
 chmod 600 $final_path/lufi.conf
 chown $app:$app $final_path/lufi.conf

--- a/scripts/install
+++ b/scripts/install
@@ -27,6 +27,7 @@ domain=$YNH_APP_ARG_DOMAIN
 path_url=$YNH_APP_ARG_PATH
 max_file_size=$YNH_APP_ARG_MAX_FILE_SIZE
 is_public=$YNH_APP_ARG_IS_PUBLIC
+use_ldap=$YNH_APP_ARG_USE_LDAP
 secret=$(ynh_string_random --length=24)
 
 app=$YNH_APP_INSTANCE_NAME
@@ -54,7 +55,7 @@ ynh_script_progression --message="Storing installation settings..."
 
 ynh_app_setting_set --app=$app --key=domain --value=$domain
 ynh_app_setting_set --app=$app --key=path --value=$path_url
-ynh_app_setting_set --app=$app --key=is_public --value=$is_public
+ynh_app_setting_set --app=$app --key=use_ldap --value=$use_ldap
 ynh_app_setting_set --app=$app --key=max_file_size --value=$max_file_size
 ynh_app_setting_set --app=$app --key=secret --value=$secret
 
@@ -139,11 +140,12 @@ if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
 fi
 ynh_replace_string --match_string="__SECRET__" --replace_string="$secret" --target_file="$config"
 
-if [ $is_public -eq 0 ];
+if [ $use_ldap -eq 1 ];
 then
-	ynh_replace_string --match_string="__IS_PUBLIC__" --replace_string="" --target_file="$config"
+	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="" --target_file="$config"
+	ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
 else
-	ynh_replace_string --match_string="__IS_PUBLIC__" --replace_string="#" --target_file="$config"
+	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="#" --target_file="$config"
 fi
 
 ynh_store_file_checksum --file="$config"
@@ -204,17 +206,9 @@ ynh_systemd_action --service_name=$app --action="start" --line_match="Creating p
 #=================================================
 ynh_script_progression --message="Configuring permissions..."
 
-ynh_permission_update --permission="main" --add="visitors"
-
-if [ $is_public -eq 0 ]
+if [ $is_public -eq 1 ]
 then
-	if [ "$path_url" == "/" ]; then
-	    # If the path is /, clear it to prevent any error with the regex.
-	    path_url=""
-	fi
-	# Modify the domain to be used in a regex
-	domain_regex=$(echo "$domain" | sed 's@-@.@g')
-	ynh_app_setting_set --app=$app --key=protected_regex --value="$domain_regex$path_url/stats$","$domain_regex$path_url/manifest.webapp$","$domain_regex$path_url/$","$domain_regex$path_url/d/.*$","$domain_regex$path_url/m/.*$"
+	ynh_permission_update --permission="main" --add="visitors"
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,7 +18,7 @@ app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
-is_public=$(ynh_app_setting_get --app=$app --key=is_public)
+use_ldap=$(ynh_app_setting_get --app=$app --key=use_ldap)
 port=$(ynh_app_setting_get --app=$app --key=port)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 secret=$(ynh_app_setting_get --app=$app --key=secret)
@@ -70,10 +70,36 @@ if [ -z "$max_file_size" ]; then
 	ynh_app_setting_set --app=$app --key=max_file_size --value=$max_file_size
 fi
 
-# Cleaning legacy permissions
+# Check if is_public settings exist and is set to true
+was_public=$(ynh_app_setting_get --app=$app --key=is_public)
+if [ $was_public -eq 1 ]
+then
+	# Fix permissions if true
+	ynh_print_info --message="Upgrading from legacy permission..."
+	ynh_print_info --message="Legacy public instance detected, allow visitors with new permission."
+	use_ldap=0
+
+	# Add new permission to allow visitors
+	ynh_permission_update --permission="main" --add="visitors"
+
+	# Remove deprecated is_public settings
+	ynh_app_setting_delete --app=$app --key=is_public
+fi
+
+# Check if legacy permissions exists (meanning that is_public was set to false)
 if ynh_legacy_permissions_exists; then
+
+	ynh_print_info --message="Upgrading from legacy permission..."
+	ynh_print_info --message="Legacy private instance detected, keep LDAP enabled."
+
+	# Legacy private install have LDAP enabled
+	use_ldap=1
+
+	# Cleaning legacy permissions
+	ynh_print_info --message="Removing legacy permission..."
 	ynh_legacy_permissions_delete_all
 
+	# Remove deprecated is_public settings
 	ynh_app_setting_delete --app=$app --key=is_public
 fi
 
@@ -145,11 +171,12 @@ if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
 fi
 ynh_replace_string --match_string="__SECRET__" --replace_string="$secret" --target_file="$config"
 
-if [ $is_public -eq 0 ];
+if [ $use_ldap -eq 1 ];
 then
-	ynh_replace_string --match_string="__IS_PUBLIC__" --replace_string="" --target_file="$config"
+	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="" --target_file="$config"
+	ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
 else
-	ynh_replace_string --match_string="__IS_PUBLIC__" --replace_string="#" --target_file="$config"
+	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="#" --target_file="$config"
 fi
 
 ynh_store_file_checksum --file="$config"
@@ -196,24 +223,6 @@ ynh_script_progression --message="Upgrading systemd configuration..."
 
 # Create a dedicated systemd config
 ynh_add_systemd_config
-
-#=================================================
-# SETUP SSOWAT
-#=================================================
-ynh_script_progression --message="Upgrading permissions..."
-
-ynh_permission_update --permission="main" --add="visitors"
-
-if [ $is_public -eq 0 ]
-then
-	if [ "$path_url" == "/" ]; then
-	    # If the path is /, clear it to prevent any error with the regex.
-	    path_url=""
-	fi
-	# Modify the domain to be used in a regex
-	domain_regex=$(echo "$domain" | sed 's@-@.@g')
-	ynh_app_setting_set --app=$app --key=protected_regex --value="$domain_regex$path_url/stats$","$domain_regex$path_url/manifest.webapp$","$domain_regex$path_url/$","$domain_regex$path_url/d/.*$","$domain_regex$path_url/m/.*$"
-fi
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -156,30 +156,18 @@ ynh_exec_warn_less ynh_install_app_dependencies $pkg_dependencies
 #=================================================
 ynh_script_progression --message="Configuring Lufi..."
 
-config=${final_path}/lufi.conf
-ynh_backup_if_checksum_is_different --file="$config"
-cp ../conf/lufi.conf.template "$config"
-ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --target_file="$config"
-ynh_replace_string --match_string="__PATH__" --replace_string="$path_url" --target_file="$config"
-ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file="$config"
-ynh_replace_string --match_string="__DB_NAME__" --replace_string="$db_name" --target_file="$config"
-ynh_replace_string --match_string="__DB_USER__" --replace_string="$db_user" --target_file="$config"
-ynh_replace_string --match_string="__DB_PWD__" --replace_string="$db_pwd" --target_file="$config"
-ynh_replace_string --match_string="__MAX_FILE_SIZE__" --replace_string="$max_file_size" --target_file="$config"
-if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
-	ynh_replace_string --match_string="max_file_size" --replace_string="#max_file_size" --target_file="$config"
-fi
-ynh_replace_string --match_string="__SECRET__" --replace_string="$secret" --target_file="$config"
-
+ldap="#"
 if [ $use_ldap -eq 1 ];
 then
-	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="" --target_file="$config"
-	ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$config"
-else
-	ynh_replace_string --match_string="__USE_LDAP__" --replace_string="#" --target_file="$config"
+	ldap=""
 fi
 
-ynh_store_file_checksum --file="$config"
+max_size_set=""
+if [ $max_file_size -eq 0 ]; then # Comment the limitation line if no limit
+	max_size_set="#"
+fi
+
+ynh_add_config --template="../conf/lufi.conf.template" --destination="$final_path/lufi.conf"
 
 chmod 600 $final_path/lufi.conf
 chown $app:$app $final_path/lufi.conf


### PR DESCRIPTION
## Problem

Closes #68 

I wanted to allow installing Luti with LDAP with public visibility and remove legacy permission.

## Solution
- I ask on install if the user wants to enable LDAP.
- I put the LDAP user filter from the [documentation](https://yunohost.org/en/packaging_apps_permissions) in Lufi config.
- I upgrade permissions depending on if `is_public` or legacy permission still exists.


## Other changes
- I replaces `ynh_replace_string` usage by `ynh_add_config`.
- I removed the deprecated redirect in nginx config.
- I bumped the package version.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
  - I at least try to install and remove it on my machine.
  - I also tried the user filter and it works.

![summary](https://user-images.githubusercontent.com/17492366/150300808-556e8ef2-25f7-4714-8c83-7e3d19f3b3b2.png)


## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
